### PR TITLE
Fix three critical code bugs

### DIFF
--- a/script.js
+++ b/script.js
@@ -60,11 +60,12 @@ function createParticles(container) {
         const size = Math.random() * 4 + 1;
         particle.style.width = `${size}px`;
         particle.style.height = `${size}px`;
-        
-        const angle = Math.random() * 360;
+
+        // Use radians directly for trigonometric functions
+        const angleRad = Math.random() * Math.PI * 2;
         const radius = (Math.random() * 40) + 40;
-        const x = Math.cos(angle) * radius + (container.offsetWidth / 2);
-        const y = Math.sin(angle) * radius + (container.offsetHeight / 2);
+        const x = Math.cos(angleRad) * radius + (container.offsetWidth / 2);
+        const y = Math.sin(angleRad) * radius + (container.offsetHeight / 2);
         
         particle.style.left = `${x}px`;
         particle.style.top = `${y}px`;
@@ -77,17 +78,20 @@ function createParticles(container) {
         particle.style.animationDirection = `alternate`;
     }
 
-    // Add a keyframe rule dynamically for floating effect
-    const styleSheet = document.styleSheets[0];
-    const keyframes = `
-        @keyframes float {
-            0% { transform: translate(0, 0); }
-            100% { transform: translate(${Math.random() * 10 - 5}px, ${Math.random() * 10 - 5}px); }
-        }`;
-    try {
-         styleSheet.insertRule(keyframes, styleSheet.cssRules.length);
-    } catch(e) {
-        console.warn("Could not insert keyframe rule:", e);
+    // Add a keyframe rule dynamically for floating effect only once per page load
+    if (!window._floatKeyframeInserted) {
+        const styleSheet = document.styleSheets[0];
+        const keyframes = `
+            @keyframes float {
+                0% { transform: translate(0, 0); }
+                100% { transform: translate(${Math.random() * 10 - 5}px, ${Math.random() * 10 - 5}px); }
+            }`;
+        try {
+            styleSheet.insertRule(keyframes, styleSheet.cssRules.length);
+            window._floatKeyframeInserted = true;
+        } catch (e) {
+            console.warn("Could not insert keyframe rule:", e);
+        }
     }
 }
 


### PR DESCRIPTION
Correct particle distribution by using radians for trigonometric functions and prevent stylesheet bloat by inserting `@keyframes float` only once.

The original code used degrees (0-360) for `Math.sin` and `Math.cos`, which expect radians, leading to incorrect particle distribution. Additionally, the `@keyframes float` rule was repeatedly inserted into the stylesheet, causing bloat and potential performance issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a9bd71a-ae41-45e7-8f11-989452074b1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3a9bd71a-ae41-45e7-8f11-989452074b1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

